### PR TITLE
mysql-tester/src: fix build

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -144,16 +144,7 @@ func newTester(name string) *tester {
 
 func setHashJoinConcurrency(db *sql.DB) {
 	if _, err := db.Exec("SET @@tidb_hash_join_concurrency=1"); err != nil {
-		var ignoreErr = false
-		if warning, ok := err.(mysql.MySQLWarnings); ok {
-			// code "1287" is ErrWarnDeprecatedSyntax
-			if len(warning) > 0 && warning[0].Code == "1287" {
-				ignoreErr = true
-			}
-		}
-		if !ignoreErr {
-			log.Fatalf("Executing \"SET @@tidb_hash_join_concurrency=1\" err[%v]", err)
-		}
+		log.Fatalf("Executing \"SET @@tidb_hash_join_concurrency=1\" err[%v]", err)
 	}
 }
 


### PR DESCRIPTION
This fixes the following error:
```
/home/morgo/go/pkg/mod/github.com/pingcap/mysql-tester@v0.0.0-20211122021422-33200960bc14/src/main.go:148:26: undefined: mysql
```

It was introduced in https://github.com/pingcap/mysql-tester/pull/33