### PR TITLE
Receive error when trying to connect.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,14 @@ make
 Basic usage:
 ```
 Usage of ./mysql-tester:
+  -all
+        run all tests
   -host string
         The host of the TiDB/MySQL server. (default "127.0.0.1")
   -log-level string
         The log level of mysql-tester: info, warn, error, debug. (default "error")
+  -params string
+        Additional params pass as DSN(e.g. session variable)
   -passwd string
         The password for the user.
   -port string
@@ -28,9 +32,13 @@ Usage of ./mysql-tester:
   -record
         Whether to record the test output to the result file.
   -reserve-schema
-    	Reserve schema after each test
+        Reserve schema after each test
+  -retry-connection-count int
+        The max number to retry to connect to the database. (default 120)
   -user string
         The user for connecting to the database. (default "root")
+  -xunitfile string
+        The xml file path to record testing results.
 ```
 
 By default, it connects to the TiDB/MySQL server at `127.0.0.1:4000` with `root` and no passward:

--- a/src/main.go
+++ b/src/main.go
@@ -176,13 +176,7 @@ func isTiDB(db *sql.DB) bool {
 func (t *tester) addConnection(connName, hostName, userName, password, db string) {
 	mdb, err := OpenDBWithRetry("mysql", userName+":"+password+"@tcp("+hostName+":"+port+")/"+db+"?time_zone=%27Asia%2FShanghai%27&allowAllFiles=true"+params)
 	if err != nil {
-		for _, tStr := range t.expectedErrs {
-			if strings.Contains(err.Error(), tStr) {
-				err = nil
-				break
-			}
-		}
-		if err != nil {
+		if t.expectedErrs == nil {
 			log.Fatalf("Open db err %v", err)
 		}
 		return

--- a/src/main.go
+++ b/src/main.go
@@ -182,9 +182,10 @@ func (t *tester) addConnection(connName, hostName, userName, password, db string
 				break
 			}
 		}
-	}
-	if err != nil {
-		log.Fatalf("Open db err %v", err)
+		if err != nil {
+			log.Fatalf("Open db err %v", err)
+		}
+		return
 	}
 	if isTiDB(mdb) {
 		if _, err = mdb.Exec("SET @@tidb_init_chunk_size=1"); err != nil {

--- a/src/util.go
+++ b/src/util.go
@@ -27,12 +27,11 @@ import (
 func OpenDBWithRetry(driverName, dataSourceName string) (mdb *sql.DB, err error) {
 	startTime := time.Now()
 	sleepTime := time.Millisecond * 500
-	retryCnt := 120
 	// The max retry interval is 60 s.
-	for i := 0; i < retryCnt; i++ {
+	for i := 0; i < retryConnCount; i++ {
 		mdb, err = sql.Open(driverName, dataSourceName)
 		if err != nil {
-			log.Warnf("open db failed, retry count %d err %v", i, err)
+			log.Warnf("open db failed, retry count %d (remain %d) err %v", i, retryConnCount-i, err)
 			time.Sleep(sleepTime)
 			continue
 		}
@@ -40,7 +39,7 @@ func OpenDBWithRetry(driverName, dataSourceName string) (mdb *sql.DB, err error)
 		if err == nil {
 			break
 		}
-		log.Warnf("ping db failed, retry count %d err %v", i, err)
+		log.Warnf("ping db failed, retry count %d (remain %d) err %v", i, retryConnCount-i, err)
 		mdb.Close()
 		time.Sleep(sleepTime)
 	}


### PR DESCRIPTION
In some tests, we expect some errors to happen in connection, such as *fail to connect to a locked user*.

So this PR makes it available to receive such errors, and configure the retry times as you like.