### PR TITLE
set tidb_enable_analyze_snapshot druing test

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/yisaer/mysql-tester
+module github.com/pingcap/mysql-tester
 
 go 1.12
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/pingcap/mysql-tester
+module github.com/yisaer/mysql-tester
 
 go 1.12
 

--- a/src/main.go
+++ b/src/main.go
@@ -160,6 +160,7 @@ func setSessionVariable(db *sql.DB) {
 	if _, err := db.Exec("SET @@tidb_enable_pseudo_for_outdated_stats=false"); err != nil {
 		log.Fatalf("Executing \"SET @@tidb_enable_pseudo_for_outdated_stats=false\" err[%v]", err)
 	}
+	// enable tidb_enable_analyze_snapshot in order to let analyze request with SI isolation level to get accurate response
 	if _, err := db.Exec("SET @@tidb_enable_analyze_snapshot=1"); err != nil {
 		log.Fatalf("Executing \"SET @@tidb_enable_analyze_snapshot=1\" err[%v]", err)
 	}

--- a/src/main.go
+++ b/src/main.go
@@ -160,6 +160,9 @@ func setSessionVariable(db *sql.DB) {
 	if _, err := db.Exec("SET @@tidb_enable_pseudo_for_outdated_stats=false"); err != nil {
 		log.Fatalf("Executing \"SET @@tidb_enable_pseudo_for_outdated_stats=false\" err[%v]", err)
 	}
+	if _, err := db.Exec("SET @@tidb_enable_analyze_snapshot=1"); err != nil {
+		log.Fatalf("Executing \"SET @@tidb_enable_analyze_snapshot=1\" err[%v]", err)
+	}
 }
 
 // isTiDB returns true if the DB is confirmed to be TiDB


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

ref https://github.com/pingcap/tidb/issues/36983
ref https://github.com/tikv/tikv/issues/13258

Previously, we use `SI` for analyze request. As RC may ignore some txnLock if the secondary keys commit havn't been finished. However, it will also meet txn conflict if we directly use maxts with SI isolevel. 

Thus we decided to use tidb_enable_analyze_snapshot to control the analyze isolevel behavior, and make it enabled for mysql-test

test by https://github.com/pingcap/tidb-test/pull/1928