### PR TITLE
check tidb version for tidb_enable_analyze_snapshot

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.12
 
 require (
 	github.com/benbjohnson/clock v1.3.0 // indirect
+	github.com/coreos/go-semver v0.3.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/pingcap/errors v0.11.5-0.20211009033009-93128226aaa3
 	github.com/pingcap/log v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/benbjohnson/clock v1.3.0 h1:ip6w0uFQkncKQ979AypyG0ER7mqUSBdKLOgAle/AT8A=
 github.com/benbjohnson/clock v1.3.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
+github.com/coreos/go-semver v0.3.0 h1:wkHLiw0WNATZnSG7epLsujiMCgPAc9xhjJ4tgnAxmfM=
+github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/cznic/mathutil v0.0.0-20181122101859-297441e03548/go.mod h1:e6NPNENfs9mPDVNRekM7lKScauxd5kXTr1Mfyig6TDM=
 github.com/cznic/sortutil v0.0.0-20181122101858-f5f958428db8/go.mod h1:q2w6Bg5jeox1B+QkJ6Wp/+Vn0G/bo3f1uY7Fn3vivIQ=
 github.com/cznic/strutil v0.0.0-20171016134553-529a34b1c186/go.mod h1:AHHPPPXTw0h6pVabbcbyGRK1DckRn7r/STdZEeIDzZc=

--- a/src/main.go
+++ b/src/main.go
@@ -26,6 +26,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/coreos/go-semver/semver"
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/pingcap/errors"
 	"github.com/pingcap/tidb/parser"
@@ -162,10 +163,44 @@ func setSessionVariable(db *sql.DB) {
 	if _, err := db.Exec("SET @@tidb_enable_pseudo_for_outdated_stats=false"); err != nil {
 		log.Fatalf("Executing \"SET @@tidb_enable_pseudo_for_outdated_stats=false\" err[%v]", err)
 	}
-	// enable tidb_enable_analyze_snapshot in order to let analyze request with SI isolation level to get accurate response
-	if _, err := db.Exec("SET @@tidb_enable_analyze_snapshot=1"); err != nil {
-		log.Fatalf("Executing \"SET @@tidb_enable_analyze_snapshot=1\" err[%v]", err)
+	rows, err := db.Query("select version from INFORMATION_SCHEMA.CLUSTER_INFO where type = 'tidb' limit 1;")
+	if err != nil {
+		log.Fatalf("Executing \"select version from INFORMATION_SCHEMA.CLUSTER_INFO where type = 'tidb' limit 1;\" err[%v]", err)
 	}
+	defer rows.Close()
+	var version string
+	for rows.Next() {
+		err := rows.Scan(&version)
+		if err != nil {
+			log.Fatalf("Executing \"select version from INFORMATION_SCHEMA.CLUSTER_INFO where type = 'tidb' limit 1;\" err[%v]", err)
+		}
+	}
+	isVersionAble, err := checkVersion(version)
+	if err != nil {
+		log.Fatalf("Comparing version failed, err[%v]", err)
+	}
+	if isVersionAble {
+		log.Infof("setting tidb_enable_analyze_snapshot due to valid tidb version[%s]", version)
+		// enable tidb_enable_analyze_snapshot in order to let analyze request with SI isolation level to get accurate response
+		if _, err := db.Exec("SET @@tidb_enable_analyze_snapshot=1"); err != nil {
+			log.Fatalf("Executing \"SET @@tidb_enable_analyze_snapshot=1\" err[%v]", err)
+		}
+	} else {
+		log.Infof("skip setting tidb_enable_analyze_snapshot due to lower tidb version[%s]", version)
+	}
+}
+
+func checkVersion(version string) (bool, error) {
+	minVersion := *semver.New("6.2.0-alpha")
+	ver, err := semver.NewVersion(version)
+	if err != nil {
+		return false, fmt.Errorf("invalid version: %s", version)
+	}
+	v := ver.Compare(minVersion)
+	if v < 0 {
+		return false, nil
+	}
+	return true, nil
 }
 
 // isTiDB returns true if the DB is confirmed to be TiDB

--- a/src/main.go
+++ b/src/main.go
@@ -175,11 +175,11 @@ func setSessionVariable(db *sql.DB) {
 			log.Fatalf("Executing \"select version from INFORMATION_SCHEMA.CLUSTER_INFO where type = 'tidb' limit 1;\" err[%v]", err)
 		}
 	}
-	isVersionAble, err := checkVersion(version)
+	isSupportedVersion, err := checkVersion(version)
 	if err != nil {
 		log.Fatalf("Comparing version failed, err[%v]", err)
 	}
-	if isVersionAble {
+	if isSupportedVersion {
 		log.Infof("setting tidb_enable_analyze_snapshot due to valid tidb version[%s]", version)
 		// enable tidb_enable_analyze_snapshot in order to let analyze request with SI isolation level to get accurate response
 		if _, err := db.Exec("SET @@tidb_enable_analyze_snapshot=1"); err != nil {


### PR DESCRIPTION
Signed-off-by: yisaer <disxiaofei@163.com>

`tidb_enable_analyze_snapshot` is introduced in `v6.2.0-alpha` which may block the ci progress if tidb-version is under v6.2.0-alpha

This requests check version in order to skip this problem. I tested with `master` version and `v6.0.0` version like following:

master
```sh
INFO[0000] running tests: [filesort_merge]              
WARN[0000] Create new db&{0 0xc000010098 0 {0 0} [0xc0001427e0] map[] 0 1 0xc000102120 false map[0xc0001427e0:map[0xc0001427e0:true]] map[] 0 0 0 0 <nil> 0 0 0 0 0x108b2e0} 
INFO[0000] setting tidb_enable_analyze_snapshot due to valid tidb version[6.3.0-alpha] 
./t/filesort_merge.test: ok! 33 test cases passed, take time 3.683121789 s
INFO[0004] run test [filesort_merge] ok                 

Great, All tests passed
```

v6.0.0
```sh
INFO[0000] running tests: [filesort_merge]              
WARN[0000] Create new db&{0 0xc0000b2090 0 {0 0} [0xc0000ea750] map[] 0 1 0xc000090120 false map[0xc0000ea750:map[0xc0000ea750:true]] map[] 0 0 0 0 <nil> 0 0 0 0 0x108b2e0} 
INFO[0000] skip setting tidb_enable_analyze_snapshot due to lower tidb version[6.0.0] 
./t/filesort_merge.test: ok! 33 test cases passed, take time 2.348324801 s
INFO[0002] run test [filesort_merge] ok                 

Great, All tests passed

```