### PR TITLE
do not set the tidb_enable_clustered_index global variable

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -171,9 +171,6 @@ func setSessionVariable(db *sql.DB) {
 	if _, err := db.Exec("SET @@tidb_enable_clustered_index='int_only'"); err != nil {
 		log.Fatalf("Executing \"SET @@tidb_enable_clustered_index='int_only'\" err[%v]", err)
 	}
-	if _, err := db.Exec("SET @@global.tidb_enable_clustered_index='int_only'"); err != nil {
-		log.Fatalf("Executing \"SET @@tidb_enable_clustered_index='int_only'\" err[%v]", err)
-	}
 }
 
 // isTiDB returns true if the DB is confirmed to be TiDB


### PR DESCRIPTION
Fix the error like `[Error 1227: Access denied; you need (at least one of) the SUPER or SYSTEM_VARIABLES_ADMIN privilege(s) for this operation]`.