### PR TITLE
mysql_tester: support sub dir

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -252,11 +252,13 @@ func (t *tester) preProcess() {
 
 	log.Warn("Create new db", mdb)
 
-	if _, err = mdb.Exec(fmt.Sprintf("create database `%s`", t.name)); err != nil {
-		log.Fatalf("Executing create db %s err[%v]", t.name, err)
+	dbName = t.name
+	dbName = strings.ReplaceAll(dbName, "/", "_")
+	if _, err = mdb.Exec(fmt.Sprintf("create database `%s`", dbName)); err != nil {
+		log.Fatalf("Executing create db %s err[%v]", dbName, err)
 	}
 
-	if _, err = mdb.Exec(fmt.Sprintf("use `%s`", t.name)); err != nil {
+	if _, err = mdb.Exec(fmt.Sprintf("use `%s`", dbName)); err != nil {
 		log.Fatalf("Executing Use test err[%v]", err)
 	}
 	if isTiDB(mdb) {
@@ -275,7 +277,9 @@ func (t *tester) preProcess() {
 
 func (t *tester) postProcess() {
 	if !reserveSchema {
-		t.mdb.Exec(fmt.Sprintf("drop database `%s`", t.name))
+		dbName := t.name
+		dbName = strings.ReplaceAll(dbName, "/", "_")
+		t.mdb.Exec(fmt.Sprintf("drop database `%s`", dbName))
 	}
 	for _, v := range t.conn {
 		v.mdb.Close()

--- a/src/main.go
+++ b/src/main.go
@@ -932,10 +932,16 @@ func (t *tester) testFileName() string {
 	return fmt.Sprintf("./t/%s.test", t.name)
 }
 
+func hasCollationPrefix(name string) bool {
+	names := strings.Split(name, "/")
+	caseName := names[len(names)-1]
+	return strings.HasPrefix(caseName, "collation")
+}
+
 func (t *tester) resultFileName() string {
 	// test and result must be in current ./r, the same as MySQL
 	name := t.name
-	if strings.HasPrefix(name, "collation") {
+	if hasCollationPrefix(name) {
 		if collationDisable {
 			name = name + "_disabled"
 		} else {
@@ -955,7 +961,7 @@ func loadAllTests() ([]string, error) {
 
 		if !info.IsDir() && strings.HasSuffix(path, ".test") {
 			name := strings.TrimPrefix(strings.TrimSuffix(path, ".test"), "t/")
-			if !collationDisable || strings.HasPrefix(name, "collation") {
+			if !collationDisable || hasCollationPrefix(name) {
 				tests = append(tests, name)
 			}
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -610,7 +610,7 @@ func (t *tester) parserErrorHandle(query query, err error) error {
 	}
 	err = syntaxError(err)
 	for _, expectedErr := range t.expectedErrs {
-		if expectedErr == "ER_PARSE_ERROR" {
+		if expectedErr == "ER_PARSE_ERROR" || expectedErr == "1064" {
 			t.writeError(query, err)
 			err = nil
 			break
@@ -715,23 +715,6 @@ func (t *tester) execute(query query) error {
 	}
 	list, _, err := t.ctx.Parse(query.Query, "", "")
 	if err != nil {
-		if len(t.expectedErrs) > 0 {
-			for _, tStr := range t.expectedErrs {
-				// parser error code is 1064
-				if strings.Contains(tStr, "1064") {
-					fmt.Fprintf(&t.buf, "%s\n", query.Query)
-					fmt.Fprintf(&t.buf,
-						"ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use %s\n",
-						strings.TrimSpace(strings.ReplaceAll(err.Error(), "\r", "")))
-					err = nil
-					break
-				}
-			}
-			t.expectedErrs = nil
-		}
-		if err == nil {
-			return nil
-		}
 		return t.parserErrorHandle(query, err)
 	}
 

--- a/src/main.go
+++ b/src/main.go
@@ -722,7 +722,7 @@ func (t *tester) execute(query query) error {
 					fmt.Fprintf(&t.buf, "%s\n", query.Query)
 					fmt.Fprintf(&t.buf,
 						"ERROR 1064 (42000): You have an error in your SQL syntax; check the manual that corresponds to your TiDB version for the right syntax to use %s\n",
-						strings.ReplaceAll(err.Error(), "\r", ""))
+						strings.TrimSpace(strings.ReplaceAll(err.Error(), "\r", "")))
 					err = nil
 					break
 				}


### PR DESCRIPTION
Do three things in this PR
1. support test cases in sub dir
2. when create a sub dir, mysql_tester will use `_` instead of `\` in database name. For example, if we have a sub dir test cases like `types/const_test.go`, it will use database named `types_const` instead of `types/const`