### PR TITLE
fix comparison between NULL and empty string ""

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -869,6 +869,16 @@ func (rows *byteRows) Less(i, j int) bool {
 			return true
 		case 1:
 			return false
+		case 0:
+			// bytes.Compare(nil, []byte{}) returns 0
+			// But in sql row representation, they are NULL and empty string "" respectively, and thus not equal.
+			// So we need special logic to handle here: make NULL < ""
+			if r1.data[i] == nil && r2.data[i] != nil {
+				return true
+			}
+			if r1.data[i] != nil && r2.data[i] == nil {
+				return false
+			}
 		}
 	}
 	return false


### PR DESCRIPTION

```
create table t (a int, b datetime, c varchar(255)) partition by range columns (a,b,c)(partition p1 values less than (-2147483648,'0000-00-00',""),partition p2 values less than (10,'2022-01-01',"Wow"),partition p3 values less than (11,'2022-01-01',MAXVALUE),partition p4 values less than (MAXVALUE,'2022-01-01',"Wow"));

set @@sql_mode = '';

insert into t values (-2147483648,'0000-00-00',null);
insert into t values (-2147483648,'0000-00-00',"");

--sorted_result
select * from t where a < 2;
```

The result is unstable even with `--sorted_result`, caused by a bug.

For NULL and empty string "", we compare them using `bytes.Compare()` and get result 0, that's incorrect.