### PR TITLE
update enable_info

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -16,3 +16,5 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/go-sql-driver/mysql v1.7.1 => github.com/defined2014/mysql v0.0.0-20231117092812-9bc18244ae3e

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-sql-driver/mysql v1.7.1 h1:lUIinVbN1DY0xBg0eMOzmmtGoHwWBbvnWubQUrtU8EI=
-github.com/go-sql-driver/mysql v1.7.1/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/defined2014/mysql v0.0.0-20231117092812-9bc18244ae3e h1:LpeLPRxRsRvgUeZlsnSt1Poh4GqAtskuTMUrkoGhkZQ=
+github.com/defined2014/mysql v0.0.0-20231117092812-9bc18244ae3e/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
 github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32 h1:m5ZsBa5o/0CkzZXfXLaThzKuR85SnHHetqBCpzQ30h8=
 github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/r/example.result
+++ b/r/example.result
@@ -11,3 +11,18 @@ explain analyze select * from t;
 id	estRows	actRows	task	access object	execution info	operator info	memory	disk
 TableReader_5	10000.00	5	root	NULL	time:<num>, loops:<num>, RU:<num>, cop_task: {num:<num>, max:<num>, proc_keys:<num>, rpc_num:<num>, rpc_time:<num>, copr_cache_hit_ratio:<num>, build_task_duration:<num>, max_distsql_concurrency:<num>}	data:TableFullScan_4	<num> Bytes	N/A
 └─TableFullScan_4	10000.00	5	cop[tikv]	table:t	tikv_task:{time:<num>, loops:<num>}	keep order:false, stats:pseudo	N/A	N/A
+insert into t values (6, 6);
+affected rows: 1
+info: 
+DROP TABLE IF EXISTS t1;
+affected rows: 0
+info: 
+CREATE TABLE t1 (f1 INT PRIMARY KEY, f2 INT NOT NULL UNIQUE);
+affected rows: 0
+info: 
+INSERT t1 VALUES (1, 1);
+affected rows: 1
+info: 
+INSERT t1 VALUES (1, 1), (1, 1) ON DUPLICATE KEY UPDATE f1 = 2, f2 = 2;
+affected rows: 3
+info: Records: 2  Duplicates: 1  Warnings: 0

--- a/t/example.test
+++ b/t/example.test
@@ -7,3 +7,12 @@ explain analyze format='brief' select * from t;
 
 --replace_regex /:[ ]?[.0-9]+.*?,/:<num>,/ /:[ ]?[.0-9]+.*?}/:<num>}/ /[0-9]+ Bytes/<num> Bytes/
 explain analyze select * from t;
+
+--enable_info
+insert into t values (6, 6);
+
+DROP TABLE IF EXISTS t1;
+CREATE TABLE t1 (f1 INT PRIMARY KEY, f2 INT NOT NULL UNIQUE);
+INSERT t1 VALUES (1, 1);
+INSERT t1 VALUES (1, 1), (1, 1) ON DUPLICATE KEY UPDATE f1 = 2, f2 = 2;
+--disable_info


### PR DESCRIPTION
1. Update `go-sql-driver/mysql` to support get `LastMessage()` and `RowsAffected()`. https://github.com/Defined2014/mysql/commit/9bc18244ae3e78338ca58c296038e05e6b46824f
2. Support `enable_info` and `disable_info`.