### PR TITLE
update mysql driver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,9 @@ module github.com/pingcap/mysql-tester
 go 1.19
 
 require (
-	github.com/go-sql-driver/mysql v1.7.1
+	// It forks from github.com/go-sql-driver/mysql v1.7.1
+	// We use it to get LastMessage() and RowsAffected()
+	github.com/defined2014/mysql v0.0.0-20231121061906-fcfacaa39f49
 	github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.4
@@ -16,5 +18,3 @@ require (
 	golang.org/x/sys v0.5.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/go-sql-driver/mysql v1.7.1 => github.com/defined2014/mysql v0.0.0-20231117092812-9bc18244ae3e

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/defined2014/mysql v0.0.0-20231117092812-9bc18244ae3e h1:LpeLPRxRsRvgUeZlsnSt1Poh4GqAtskuTMUrkoGhkZQ=
-github.com/defined2014/mysql v0.0.0-20231117092812-9bc18244ae3e/go.mod h1:OXbVy3sEdcQ2Doequ6Z5BW6fXNQTmx+9S1MCJN5yJMI=
+github.com/defined2014/mysql v0.0.0-20231121061906-fcfacaa39f49 h1:Q3Ri7Ycix4T+Ig7I896I6w0WuCajid2SgyierI16NSo=
+github.com/defined2014/mysql v0.0.0-20231121061906-fcfacaa39f49/go.mod h1:5GYlY+PrT+c8FHAJTMIsyOuHUNf62KAQuRPMGssbixo=
 github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32 h1:m5ZsBa5o/0CkzZXfXLaThzKuR85SnHHetqBCpzQ30h8=
 github.com/pingcap/errors v0.11.5-0.20221009092201-b66cddb77c32/go.mod h1:X2r9ueLEUZgtx2cIogM0v4Zj5uvvzhuuiu7Pn8HzMPg=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/main.go
+++ b/src/main.go
@@ -28,7 +28,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/go-sql-driver/mysql"
+	"github.com/defined2014/mysql"
 	"github.com/pingcap/errors"
 	log "github.com/sirupsen/logrus"
 )


### PR DESCRIPTION
Delete `replace` in `go.mod` which will cause `go install` failed. **Related issue**, https://github.com/golang/go/issues/44840

Use `github.com/defined2014/mysql` instead of `github.com/go-sql-driver/mysql`. https://github.com/Defined2014/mysql/commit/fcfacaa39f4926958728ea910de651fedfa374cc