### PR TITLE
Makefile: use variable for Go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,23 +1,25 @@
 .PHONY: all build test tidy clean
 
+GO := go
+
 default: build
 
 build:
-	go build -o mysql-tester ./src
+	$(GO) build -o mysql-tester ./src
 
 debug:
-	go build -gcflags="all=-N -l" -o mysql-tester ./src
+	$(GO) build -gcflags="all=-N -l" -o mysql-tester ./src
 
 test: build
-	go test -cover ./...
+	$(GO) test -cover ./...
 	#./mysql-tester -check-error
 
 tidy:
-	go mod tidy
+	$(GO) mod tidy
 
 clean:
-	go clean -i ./...
+	$(GO) clean -i ./...
 	rm -rf mysql-tester
 
 gen_perror: generate_perror/main.go
-	go build -o gen_perror ./generate_perror
+	$(GO) build -o gen_perror ./generate_perror


### PR DESCRIPTION
This allows one to run things like:
* `make GO=gotip build`
* `make GO=go1.21rc3 build`