### PR TITLE
Fix issues reported by `golangci-lint`

### DIFF
--- a/generate_perror/main.go
+++ b/generate_perror/main.go
@@ -78,7 +78,7 @@ func scanErrCodeFile(fileName string, nameToNum map[string]int) {
 	r := regexp.MustCompile(`^\s+(\w+)*\s+=\s+(\d+)$`)
 	for s.Scan() {
 		m := r.FindStringSubmatch(s.Text())
-		if m != nil && len(m) == 3 && m[1] != "" && m[2] != "" {
+		if len(m) == 3 && m[1] != "" && m[2] != "" {
 			i, err := strconv.Atoi(m[2])
 			if err != nil {
 				log.Fatal(err)
@@ -134,7 +134,7 @@ func main() {
 		r := regexp.MustCompile(`^MySQL error code MY-0*(\d+) \((\w+)\)`)
 		for s.Scan() {
 			m := r.FindStringSubmatch(s.Text())
-			if m != nil && len(m) == 3 && m[1] != "" && m[2] != "" {
+			if len(m) == 3 && m[1] != "" && m[2] != "" {
 				c, err := strconv.Atoi(m[1])
 				if err != nil {
 					log.Fatal(err)
@@ -145,7 +145,10 @@ func main() {
 				checkNewErr(m[2], i, NameToNum)
 			}
 		}
-		cmd.Wait()
+		err = cmd.Wait()
+		if err != nil {
+			log.Fatal(err)
+		}
 	}
 	if maxError >= 1000 {
 		fmt.Printf("\r")
@@ -170,7 +173,7 @@ func main() {
 	sort.Slice(codes, func(i, j int) bool {
 		return codes[i].Code < codes[j].Code || codes[i].Code == codes[j].Code && codes[i].Name < codes[j].Name
 	})
-	for i, _ := range codes {
+	for i := range codes {
 		_, err = w.WriteString("\t\"" + codes[i].Name + `": ` + strconv.Itoa(codes[i].Code) + ",\n")
 		if err != nil {
 			log.Fatal(err)


### PR DESCRIPTION
```
$ golangci-lint run
generate_perror/main.go:148:11: Error return value of `cmd.Wait` is not checked (errcheck)
		cmd.Wait()
		        ^
src/main.go:294:13: Error return value of `t.mdb.Exec` is not checked (errcheck)
		t.mdb.Exec(fmt.Sprintf("drop database `%s`", strings.ReplaceAll(t.name, "/", "__")))
		          ^
src/main.go:921:18: Error return value of `t.curr.conn.Raw` is not checked (errcheck)
		t.curr.conn.Raw(func(driverConn any) error {
		               ^
generate_perror/main.go:173:9: S1005: unnecessary assignment to the blank identifier (gosimple)
	for i, _ := range codes {
	       ^
generate_perror/main.go:81:6: S1009: should omit nil check; len() for []string is defined as zero (gosimple)
		if m != nil && len(m) == 3 && m[1] != "" && m[2] != "" {
		   ^
generate_perror/main.go:137:7: S1009: should omit nil check; len() for []string is defined as zero (gosimple)
			if m != nil && len(m) == 3 && m[1] != "" && m[2] != "" {
```