### PR TITLE
Add support for the source command

### DIFF
--- a/include/hello.inc
+++ b/include/hello.inc
@@ -1,0 +1,1 @@
+--echo Hello from the included file

--- a/include/hello.inc
+++ b/include/hello.inc
@@ -1,2 +1,0 @@
---echo Hello from the included file
-SELECT 1

--- a/include/hello.inc
+++ b/include/hello.inc
@@ -1,1 +1,2 @@
 --echo Hello from the included file
+SELECT 1

--- a/r/source.result
+++ b/r/source.result
@@ -1,0 +1,3 @@
+first line
+Hello from the included file
+last line

--- a/r/source.result
+++ b/r/source.result
@@ -1,3 +1,6 @@
 first line
 Hello from the included file
+SELECT 1
+1
+1
 last line

--- a/r/source.result
+++ b/r/source.result
@@ -1,6 +1,10 @@
-first line
+before source
 Hello from the included file
 SELECT 1
 1
 1
-last line
+after source
+Goodbye from the included file
+SELECT 3
+3
+3

--- a/src/main.go
+++ b/src/main.go
@@ -425,7 +425,7 @@ func (t *tester) runQueries(queries []query) (int, error) {
 			if t.enableConcurrent {
 				concurrentQueue = append(concurrentQueue, q)
 			} else if err = t.execute(q); err != nil {
-				err = errors.Annotate(err, fmt.Sprintf("sql:%v", q.Query))
+				err = errors.Annotate(err, fmt.Sprintf("sql:%v line:%s", q.Query, q.location()))
 				t.addFailure(&testSuite, &err, testCnt)
 				return testCnt, err
 			}
@@ -549,10 +549,11 @@ func (t *tester) runQueries(queries []query) (int, error) {
 			if err != nil {
 				return testCnt, errors.Annotate(err, fmt.Sprintf("error loading queries from %s", fileName))
 			}
-			_, err = t.runQueries(includedQueries)
+			includeCnt, err := t.runQueries(includedQueries)
 			if err != nil {
 				return testCnt, err
 			}
+			testCnt += includeCnt
 		default:
 			log.WithFields(log.Fields{"command": q.firstWord, "arguments": q.Query, "line": q.location()}).Warn("command not implemented")
 		}

--- a/src/main.go
+++ b/src/main.go
@@ -47,6 +47,7 @@ var (
 	retryConnCount   int
 	collationDisable bool
 	checkErr         bool
+	disableSource    bool
 )
 
 func init() {
@@ -516,7 +517,15 @@ func (t *tester) runQueries(queries []query) (int, error) {
 						q.location(), q.Query))
 			}
 			t.replaceRegex = regex
+		case Q_ENABLE_SOURCE:
+			disableSource = false
+		case Q_DISABLE_SOURCE:
+			disableSource = true
 		case Q_SOURCE:
+			if disableSource {
+				log.WithFields(log.Fields{"line": q.location()}).Warn("source command disabled")
+				break
+			}
 			fileName := strings.TrimSpace(q.Query)
 			cwd, err := os.Getwd()
 			if err != nil {

--- a/src/main.go
+++ b/src/main.go
@@ -51,6 +51,9 @@ var (
 )
 
 func init() {
+	// Disable the `--source` command by default to avoid breaking existing tests
+	disableSource = true
+
 	flag.StringVar(&host, "host", "127.0.0.1", "The host of the TiDB/MySQL server.")
 	flag.StringVar(&port, "port", "4000", "The listen port of TiDB/MySQL server.")
 	flag.StringVar(&user, "user", "root", "The user for connecting to the database.")
@@ -523,7 +526,7 @@ func (t *tester) runQueries(queries []query) (int, error) {
 			disableSource = true
 		case Q_SOURCE:
 			if disableSource {
-				log.WithFields(log.Fields{"line": q.location()}).Warn("source command disabled")
+				log.WithFields(log.Fields{"line": q.location()}).Warn("source command disabled, add '--enable_source' to your file to enable")
 				break
 			}
 			fileName := strings.TrimSpace(q.Query)

--- a/src/query.go
+++ b/src/query.go
@@ -124,6 +124,8 @@ const (
 	Q_COMMENT /* Comments, ignored. */
 	Q_COMMENT_WITH_COMMAND
 	Q_EMPTY_LINE
+	Q_DISABLE_SOURCE
+	Q_ENABLE_SOURCE
 )
 
 // ParseQueries parses an array of string into an array of query object.

--- a/src/query.go
+++ b/src/query.go
@@ -136,6 +136,7 @@ func ParseQueries(qs ...query) ([]query, error) {
 		q := query{}
 		q.tp = Q_UNKNOWN
 		q.Line = rs.Line
+		q.File = rs.File
 		// a valid query's length should be at least 3.
 		if len(s) < 3 {
 			continue

--- a/src/type.go
+++ b/src/type.go
@@ -114,6 +114,8 @@ var commandMap = map[string]int{
 	"single_query":               Q_SINGLE_QUERY,
 	"begin_concurrent":           Q_BEGIN_CONCURRENT,
 	"end_concurrent":             Q_END_CONCURRENT,
+	"disable_source":             Q_DISABLE_SOURCE,
+	"enable_source":              Q_ENABLE_SOURCE,
 }
 
 func findType(cmdName string) int {

--- a/t/source.test
+++ b/t/source.test
@@ -1,0 +1,3 @@
+--echo first line
+--source include/hello.inc
+--echo last line

--- a/t/source.test
+++ b/t/source.test
@@ -1,3 +1,5 @@
+--enable_source
+
 --echo before source
 --source include/hello1.inc
 --echo after source

--- a/t/source.test
+++ b/t/source.test
@@ -1,3 +1,9 @@
---echo first line
---source include/hello.inc
---echo last line
+--echo before source
+--source include/hello1.inc
+--echo after source
+
+--disable_source
+--source include/hello2.inc
+--enable_source
+
+--source include/hello3.inc


### PR DESCRIPTION
```
dvaneeden@dve-carbon:~/dev/pingcap/mysql-tester$ cat t/source.test 
--echo first line
--source include/hello.inc
--echo last line
dvaneeden@dve-carbon:~/dev/pingcap/mysql-tester$ cat include/hello.inc 
--echo Hello from the included file
dvaneeden@dve-carbon:~/dev/pingcap/mysql-tester$ cat r/source.result 
first line
Hello from the included file
last line
```

- A lot of places that only reported the line number, these should now report `<file>:<line>` instead.
- This improves compatibility with the official MySQL test runner from Oracle
- This has the potential to break existing tests that were defined with `--source`, but never actually ran the included files or tested for their presence.
- This tries to restrict including random files (`/etc/password`, etc)
- This does not prevent against including files in include files and causing endless loops etc

Related:
- https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_INCLUDE_FILES.html
- https://dev.mysql.com/doc/dev/mysql-server/latest/PAGE_MYSQL_TEST_COMMANDS.html  (search for `source file_name`)

## Existing tests

This disables `--source` by default and emits a warning like this:
```
WARN[0000] source command disabled, add '--enable_source' to your file to enable  line="./t/source.test:8"
```

So when porting tests one has to add `--enable-source` to the top of the file. It would probably good to change this in the future to make it enabled by default and require `--disable-source` to disable it for files where it breaks (or remove /fix the `--source` lines)