### PR TITLE
src: check remained lines after all test cases

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -528,6 +528,12 @@ func (t *tester) Run() error {
 		}
 	}
 
+	// check do we have remained lines in result file
+	buf := make([]byte, 32)
+	if n, _ := t.resultFD.ReadAt(buf, int64(t.buf.Len())); n != 0 {
+		return errors.Trace(errors.Errorf("There is extra data at the end of the result file: %s", buf))
+	}
+
 	fmt.Printf("%s: ok! %d test cases passed, take time %v s\n", t.testFileName(), testCnt, time.Since(startTime).Seconds())
 
 	if xmlPath != "" {
@@ -784,12 +790,9 @@ func (t *tester) execute(query query) error {
 	if err != nil {
 		return errors.Trace(errors.Errorf("run \"%v\" at line %d err %v", query.Query, query.Line, err))
 	}
+
 	// clear expected errors after we execute the first query
 	t.expectedErrs = nil
-
-	if err != nil {
-		return errors.Trace(errors.Errorf("run \"%v\" at line %d err %v", query.Query, query.Line, err))
-	}
 
 	if !record {
 		// check test result now


### PR DESCRIPTION
Fix https://github.com/pingcap/mysql-tester/issues/131, add a extra line in `show.result` file,

```shell
➜  integrationtest git:(master) ✗ git diff
diff --git a/tests/integrationtest/r/show.result b/tests/integrationtest/r/show.result
index 42232d8bea..410b1425f5 100644
--- a/tests/integrationtest/r/show.result
+++ b/tests/integrationtest/r/show.result
@@ -3,3 +3,4 @@ show tables like '%xx';
 Tables_in_show (%xx)
 show databases like '%xx';
 Database (%xx)
+aa
```

the result shown below
```shell
➜  integrationtest git:(master) ✗ ./run-tests.sh -t show
extracting statistics: s
skip building portgenerator, using existing binary: ./portgenerator
start tidb-server, log file: ./integration-test.out
tidb-server(PID: 28692) started
run integration test cases(enabled new collation): show
ERRO[0001] run test [show] err: There is extra data at the end of the result file: aa


ERRO[0001] 1 tests failed
ERRO[0001] run test [show] err: There is extra data at the end of the result file: aa
```