### PR TITLE
support recording data from multiple result set

### DIFF
--- a/r/multi_query.result
+++ b/r/multi_query.result
@@ -1,0 +1,11 @@
+set global tidb_enable_procedure = ON;
+CREATE PROCEDURE multi_select()
+BEGIN
+SELECT 1;
+SELECT 2, 3;
+END//
+CALL multi_select();
+1
+1
+2	3
+2	3

--- a/t/multi_query.test
+++ b/t/multi_query.test
@@ -1,0 +1,12 @@
+set global tidb_enable_procedure = ON;
+DELIMITER //
+
+CREATE PROCEDURE multi_select()
+BEGIN
+    SELECT 1;
+    SELECT 2, 3;
+END//
+
+DELIMITER ;
+
+CALL multi_select();


### PR DESCRIPTION
Before this PR, a query with multiple result sets may get stuck.

```sql
SET GLOBAL tidb_enable_procedure = ON;
DELIMITER //
CREATE PROCEDURE multi_select()
BEGIN
    SELECT 1;
    SELECT 2, 3;
END//
DELIMITER ;

CALL multi_select();
```

```
❯ go run ./src/. -record multi_query
^\SIGQUIT: quit
PC=0x475e81 m=0 sigcode=128

...
goroutine 20 gp=0xc000188700 m=nil [sync.RWMutex.Lock]:
runtime.gopark(0xc0000d2080?, 0xc0001f75d0?, 0xe0?, 0x44?, 0xc0001f7640?)
        /usr/local/go/src/runtime/proc.go:424 +0xce fp=0xc0001f75b8 sp=0xc0001f7598 pc=0x46c80e
runtime.goparkunlock(...)
        /usr/local/go/src/runtime/proc.go:430
runtime.semacquire1(0xc000150010, 0x0, 0x3, 0x0, 0x17)
        /usr/local/go/src/runtime/sema.go:178 +0x225 fp=0xc0001f7620 sp=0xc0001f75b8 pc=0x44bf05
sync.runtime_SemacquireRWMutex(0xc0000d2080?, 0x78?, 0x51fbe5?)
        /usr/local/go/src/runtime/sema.go:105 +0x25 fp=0xc0001f7658 sp=0xc0001f7620 pc=0x46de25
sync.(*RWMutex).Lock(0x100000000000000?)
        /usr/local/go/src/sync/rwmutex.go:153 +0x6a fp=0xc0001f7688 sp=0xc0001f7658 pc=0x48912a
database/sql.(*Conn).close(0xc0001f76e8?, {0x0, 0x0})
        /usr/local/go/src/database/sql/sql.go:2130 +0x75 fp=0xc0001f7700 sp=0xc0001f7688 pc=0x51d915
database/sql.(*Conn).Close(...)
        /usr/local/go/src/database/sql/sql.go:2145
main.(*tester).postProcess.func1()
        /home/tangenta/mysql-tester/src/main.go:318 +0x7c fp=0xc0001f7790 sp=0xc0001f7700 pc=0x662d1c
main.(*tester).postProcess(0xc0001a4dd0?)
        /home/tangenta/mysql-tester/src/main.go:340 +0x2a6 fp=0xc0001f7840 sp=0xc0001f7790 pc=0x662c66
main.(*tester).Run.deferwrap1()
        /home/tangenta/mysql-tester/src/main.go:364 +0x25 fp=0xc0001f7858 sp=0xc0001f7840 pc=0x665665
...
```

This is because the SQL rows are not closed on error.

```diff
raw, err := t.curr.conn.QueryContext(context.Background(), query)
	if err != nil {
		return errors.Trace(err)
	}
+	defer raw.Close()
```

After fixing the stuck issue, another issue occurs:

```
❯ go run ./src/. -record multi_query
ERRO[0000] run test [multi_query] err: sql:CALL multi_select();: run "CALL multi_select();" at line 12 err sql: expected 2 destination arguments in Scan, not 1 

ERRO[0000] 1 tests failed                               
ERRO[0000] run test [multi_query] err: sql:CALL multi_select();: run "CALL multi_select();" at line 12 err sql: expected 2 destination arguments in Scan, not 1 
exit status 1
```

The root cause is the impl of `dumpToByteRows` does not support handling multiple result sets.

After this PR:

```
❯ go run ./src/. -record multi_query
./t/multi_query.test: ok! 3 test cases passed, take time 0.009704879 s

Great, All tests passed
```